### PR TITLE
Switch Skia's font backend to use fontconfig instead of a static directory

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -359,7 +359,8 @@ SKIA_PORTS_CXX_SRC=\
 		SkDebug_stdio.cpp \
 		SkFontHost_FreeType_common.cpp \
 		SkFontHost_FreeType.cpp \
-		SkFontHost_linux.cpp \
+		SkFontHost_fontconfig.cpp \
+		SkFontConfigInterface_direct.cpp \
 		SkOSFile_stdio.cpp \
 		SkThread_pthread.cpp)
 


### PR DESCRIPTION
This fixes issues where /usr/share/fonts/truetype did not exist (Fedora 18, etc), and moves to the same font finding backend that Servo uses.
