### PR TITLE
Destroy framebuffers, textures and renderbuffers when the context dies.

### DIFF
--- a/src/gpu/gl/mac/SkNativeSharedGLContext_mac.cpp
+++ b/src/gpu/gl/mac/SkNativeSharedGLContext_mac.cpp
@@ -19,6 +19,12 @@ SkNativeSharedGLContext::SkNativeSharedGLContext(GrGLSharedContext sharedContext
 }
 
 SkNativeSharedGLContext::~SkNativeSharedGLContext() {
+    if (fGL) {
+        SK_GL_NOERRCHECK(*this, DeleteFramebuffers(1, &fFBO));
+        SK_GL_NOERRCHECK(*this, DeleteTextures(1, &fColorBufferID));
+        SK_GL_NOERRCHECK(*this, DeleteRenderbuffers(1, &fDepthStencilBufferID));
+    }
+    SkSafeUnref(fGL);
     this->destroyGLContext();
     if (fGrContext) {
         fGrContext->Release();

--- a/src/gpu/gl/unix/SkNativeSharedGLContext_unix.cpp
+++ b/src/gpu/gl/unix/SkNativeSharedGLContext_unix.cpp
@@ -32,6 +32,12 @@ SkNativeSharedGLContext::SkNativeSharedGLContext(GrGLSharedContext sharedContext
 }
 
 SkNativeSharedGLContext::~SkNativeSharedGLContext() {
+    if (fGL) {
+        SK_GL_NOERRCHECK(*this, DeleteFramebuffers(1, &fFBO));
+        SK_GL_NOERRCHECK(*this, DeleteTextures(1, &fColorBufferID));
+        SK_GL_NOERRCHECK(*this, DeleteRenderbuffers(1, &fDepthStencilBufferID));
+    }
+    SkSafeUnref(fGL);
     this->destroyGLContext();
     glXDestroyGLXPixmap(fDisplay, fGlxPixmap);
     XFreePixmap(fDisplay, fPixmap);


### PR DESCRIPTION
r? @eschweic
