### PR TITLE
Add extra field to SkNativeSharedGLContext ctor.

### DIFF
--- a/include/gpu/gl/SkNativeSharedGLContext.h
+++ b/include/gpu/gl/SkNativeSharedGLContext.h
@@ -36,7 +36,7 @@ typedef GLXContext GrGLSharedContext;
 
 class SkNativeSharedGLContext : public SkRefCnt {
 public:
-    explicit SkNativeSharedGLContext(GrGLSharedContext sharedContext);
+    explicit SkNativeSharedGLContext(GrGLSharedContext sharedContext, void *extra);
     virtual ~SkNativeSharedGLContext();
 
     virtual bool init(const int width, const int height);

--- a/src/gpu/gl/mac/SkNativeSharedGLContext_mac.cpp
+++ b/src/gpu/gl/mac/SkNativeSharedGLContext_mac.cpp
@@ -8,7 +8,7 @@
 #include "gl/SkNativeSharedGLContext.h"
 #include "gl/GrGLUtil.h"
 
-SkNativeSharedGLContext::SkNativeSharedGLContext(GrGLSharedContext sharedContext)
+SkNativeSharedGLContext::SkNativeSharedGLContext(GrGLSharedContext sharedContext, void *extra)
     : fContext(NULL)
     , fGrContext(NULL)
     , fGL(NULL)

--- a/src/gpu/gl/unix/SkNativeSharedGLContext_unix.cpp
+++ b/src/gpu/gl/unix/SkNativeSharedGLContext_unix.cpp
@@ -8,7 +8,7 @@
 #include "gl/SkNativeSharedGLContext.h"
 #include "gl/GrGLUtil.h"
 
-SkNativeSharedGLContext::SkNativeSharedGLContext(GrGLSharedContext sharedContext)
+SkNativeSharedGLContext::SkNativeSharedGLContext(GrGLSharedContext sharedContext, void *extra)
     : fContext(NULL)
     , fGrContext(NULL)
     , fGL(NULL)
@@ -17,7 +17,7 @@ SkNativeSharedGLContext::SkNativeSharedGLContext(GrGLSharedContext sharedContext
     , fTextureID(0)
     , fDepthStencilBufferID(0) {
 
-    fDisplay = XOpenDisplay(NULL);
+    fDisplay = (Display *)extra;
     SkASSERT(NULL != fDisplay);
     int screen = DefaultScreen(fDisplay);
     GLint att[] = {
@@ -41,7 +41,6 @@ SkNativeSharedGLContext::~SkNativeSharedGLContext() {
     this->destroyGLContext();
     glXDestroyGLXPixmap(fDisplay, fGlxPixmap);
     XFreePixmap(fDisplay, fPixmap);
-    if (fDisplay) XCloseDisplay(fDisplay);
     if (fGrContext) {
         fGrContext->Release();
     }


### PR DESCRIPTION
This field is used to pass in a shared `Display*` on linux to avoid driver
bugs with shared contexts.

r? @pcwalton
