### PR TITLE
Destroy GL resources upon theft of the surface.

### DIFF
--- a/include/gpu/gl/SkNativeSharedGLContext.h
+++ b/include/gpu/gl/SkNativeSharedGLContext.h
@@ -103,6 +103,8 @@ private:
     XVisualInfo *fVisualInfo;
     Pixmap fPixmap;
     GLXPixmap fGlxPixmap;
+
+    void destroyGLResources();
 #else
 #error "No shared contexts on this platform."
 #endif


### PR DESCRIPTION
We need the GLX pixmap to stay around long enough to destroy the
resources, and the GLX pixmap is now destroyed when the pixmap is
stolen.

In the future we will want to keep around the draw target and
associate it with the pixmap ID so that we can quickly reobtain the
resources.
