### PR TITLE
Fix destruction order. Defer destroying the GL context until the

### DIFF
--- a/src/gpu/gl/unix/SkNativeSharedGLContext_unix.cpp
+++ b/src/gpu/gl/unix/SkNativeSharedGLContext_unix.cpp
@@ -49,6 +49,7 @@ void SkNativeSharedGLContext::destroyGLResources() {
         SK_GL_NOERRCHECK(*this, DeleteRenderbuffers(1, &fDepthStencilBufferID));
     }
 
+    glXMakeCurrent(fDisplay, None, NULL);
     glXDestroyGLXPixmap(fDisplay, fGlxPixmap);
     fGlxPixmap = 0;
 }


### PR DESCRIPTION
destructor so that other GL resources can be destroyed first. This
fixes crashes on some linux GPU drivers.
