### PR TITLE
config: Increase the glyph cache size to a sensible value for parallel painting.

### DIFF
--- a/include/config/SkUserConfig.h
+++ b/include/config/SkUserConfig.h
@@ -120,7 +120,7 @@
  *  To specify a different default font cache limit, define this. If this is
  *  undefined, skia will use a built-in value.
  */
-//#define SK_DEFAULT_FONT_CACHE_LIMIT   (1024 * 1024)
+#define SK_DEFAULT_FONT_CACHE_LIMIT   (12 * 1024 * 1024)
 
 /* If defined, use CoreText instead of ATSUI on OS X.
 */


### PR DESCRIPTION
The glyph cache maximum size is shared between all threads, so we need
to bump it up when we use parallel painting. Otherwise we spend 75% of
our painting time in cache misses on that glyph cache.

r? @metajack 
