### PR TITLE
Fixes for standalone builds

### DIFF
--- a/makefile.cargo
+++ b/makefile.cargo
@@ -524,7 +524,6 @@ SKIA_GL_CXX_SRC += \
 SKIA_PORTS_CXX_SRC = \
 	$(addprefix src/ports/,\
 		SkDebug_stdio.cpp \
-		SkDebug_stdio.cpp \
 		SkFontHost_mac.cpp \
 		SkGlobalInitialization_default.cpp \
 		SkImageDecoder_empty.cpp \

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,4 +19,5 @@ pub use skia::{
     SkiaSkNativeSharedGLContextFlush,
 };
 
+pub mod linkhack;
 pub mod skia;

--- a/src/linkhack.rs
+++ b/src/linkhack.rs
@@ -1,0 +1,30 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// Some crumminess to make sure we link correctly
+
+#[cfg(target_os = "linux")]
+#[link(name = "skia", kind = "static")]
+#[link(name = "stdc++")]
+#[link(name = "freetype")]
+#[link(name = "fontconfig")]
+#[link(name = "bz2")]
+#[link(name = "GL")]
+extern { }
+
+#[cfg(target_os = "android")]
+#[link(name = "skia", kind = "static")]
+#[link(name = "stdc++")]
+#[link(name = "fontconfig")]
+#[link(name = "EGL")]
+#[link(name = "GLESv2")]
+extern { }
+
+#[cfg(target_os = "macos")]
+#[link(name = "skia", kind = "static")]
+#[link(name = "stdc++")]
+#[link(name = "IOSurface", kind = "framework")]
+#[link(name = "OpenGL", kind = "framework")]
+#[link(name = "ApplicationServices", kind = "framework")]
+extern { }


### PR DESCRIPTION
When building the test harness we need to ensure that libraries are
properly linked and we avoid duplicate symbols.