### PR TITLE
Deconstify GrContext

### DIFF
--- a/src/gl_rasterization_context.rs
+++ b/src/gl_rasterization_context.rs
@@ -99,7 +99,7 @@ pub fn setup_framebuffer<F>(texture_target: gl::GLenum,
     unsafe {
         let gl_interface = skia::SkiaGrGLCreateNativeInterface();
         if gl_interface == ptr::null_mut() {
-            return (0, 0, 0, ptr::null());
+            return (0, 0, 0, ptr::null_mut());
         }
 
         clear_gl_errors();
@@ -135,7 +135,7 @@ pub fn setup_framebuffer<F>(texture_target: gl::GLenum,
         let gr_context = if !framebuffer_creation_failed {
             skia::SkiaGrContextCreate(gl_interface)
         } else {
-            ptr::null()
+            ptr::null_mut()
         };
 
         skia::SkiaGrGLInterfaceRelease(gl_interface);

--- a/src/gl_rasterization_context_android.rs
+++ b/src/gl_rasterization_context_android.rs
@@ -98,7 +98,7 @@ impl GLRasterizationContext {
                                      gl::RGBA, gl::UNSIGNED_BYTE, None);
                 });
 
-            if gr_context == ptr::null() {
+            if gr_context == ptr::null_mut() {
                 egl::MakeCurrent(display, ptr::null_mut(), ptr::null_mut(), ptr::null_mut());
                 egl::DestroyContext(display, egl_context);
                 egl::DestroySurface(display, egl_surface);

--- a/src/gl_rasterization_context_cgl.rs
+++ b/src/gl_rasterization_context_cgl.rs
@@ -65,7 +65,7 @@ impl GLRasterizationContext {
                                                 0);
                 });
 
-            if gr_context == ptr::null() {
+            if gr_context == ptr::null_mut() {
                 cgl::CGLDestroyContext(cgl_context);
                 return None;
             }

--- a/src/gl_rasterization_context_glx.rs
+++ b/src/gl_rasterization_context_glx.rs
@@ -84,7 +84,7 @@ impl GLRasterizationContext {
                                      gl::RGBA, gl::UNSIGNED_BYTE, None);
                 });
 
-            if gr_context == ptr::null() {
+            if gr_context == ptr::null_mut() {
                 glx::MakeCurrent(glx_display, 0 /* None */, ptr::null_mut());
                 glx::DestroyContext(glx_display, glx_context);
                 glx::DestroyGLXPixmap(glx_display, glx_pixmap);

--- a/src/skia-c.cpp
+++ b/src/skia-c.cpp
@@ -43,10 +43,10 @@ SkiaGrContextCreate(SkiaGrGLInterfaceRef anInterface) {
 
 extern "C" void
 SkiaGrContextRetain(SkiaGrContextRef aContext) {
-    SkSafeRef(static_cast<const GrContext*>(aContext));
+    SkSafeRef(static_cast<GrContext*>(aContext));
 }
 
 extern "C" void
 SkiaGrContextRelease(SkiaGrContextRef aContext) {
-    SkSafeUnref(static_cast<const GrContext*>(aContext));
+    SkSafeUnref(static_cast<GrContext*>(aContext));
 }

--- a/src/skia-c.h
+++ b/src/skia-c.h
@@ -7,7 +7,7 @@
 #ifndef SKIA_C_DEFINED
 #define SKIA_C_DEFINED
 
-typedef const void* SkiaGrContextRef;
+typedef void* SkiaGrContextRef;
 typedef const void* SkiaGrGLInterfaceRef;
 
 #ifdef __cplusplus

--- a/src/skia.rs
+++ b/src/skia.rs
@@ -8,7 +8,7 @@
 
 use libc::*;
 
-pub type SkiaGrContextRef = *const c_void;
+pub type SkiaGrContextRef = *mut c_void;
 pub type SkiaGrGLInterfaceRef = *const c_void;
 
 #[link(name = "skia")]


### PR DESCRIPTION
When rust-azure uses GrContext, it needs a non-const pointer. This
allows it to stop trying to cast away the constness.