### PR TITLE
Split out GLContext from GLRasterizationContext

### DIFF
--- a/src/gl_context.rs
+++ b/src/gl_context.rs
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2015 The Servo Project Developers
+ *
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
+use skia;
+
+use euclid::size::Size2D;
+use gleam::gl;
+use std::ptr;
+use std::sync::Arc;
+
+#[cfg(target_os="macos")]
+pub use gl_context_cgl::GLPlatformContext;
+#[cfg(target_os="macos")]
+pub use gl_context_cgl::PlatformDisplayData;
+
+#[cfg(target_os="linux")]
+pub use gl_context_glx::GLPlatformContext;
+#[cfg(target_os="linux")]
+pub use gl_context_glx::PlatformDisplayData;
+
+#[cfg(target_os="android")]
+pub use gl_context_android::GLPlatformContext;
+#[cfg(target_os="android")]
+pub use gl_context_android::PlatformDisplayData;
+
+pub struct GLContext {
+    pub platform_context: GLPlatformContext,
+    pub gr_context: skia::SkiaGrContextRef,
+    pub gl_interface: skia::SkiaGrGLInterfaceRef,
+    pub size: Size2D<i32>,
+}
+
+impl Drop for GLContext {
+    fn drop(&mut self) {
+        self.platform_context.make_current();
+
+        unsafe {
+            skia::SkiaGrContextRelease(self.gr_context);
+            skia::SkiaGrGLInterfaceRelease(self.gl_interface);
+        }
+    }
+}
+
+impl GLContext {
+    pub fn new(platform_display_data: PlatformDisplayData,
+               size: Size2D<i32>)
+               -> Option<Arc<GLContext>> {
+        let platform_context = GLPlatformContext::new(platform_display_data, size);
+        let platform_context = match platform_context {
+            Some(platform_context) => platform_context,
+            None => return None,
+        };
+
+        // The Skia GL interface needs to be created while the context is active, so we
+        // do that immediately after setting the context as the current one.
+        platform_context.make_current();
+
+        unsafe {
+            let gl_interface = skia::SkiaGrGLCreateNativeInterface();
+            if gl_interface == ptr::null_mut() {
+                platform_context.drop_current_context();
+                return None;
+            }
+
+            let gr_context = skia::SkiaGrContextCreate(gl_interface);
+            if gr_context == ptr::null_mut() {
+                platform_context.drop_current_context();
+                return None;
+            }
+
+            Some(Arc::new(GLContext {
+                platform_context: platform_context,
+                gr_context: gr_context,
+                gl_interface: gl_interface,
+                size: size,
+            }))
+        }
+   }
+
+    pub fn flush(&self) {
+        self.make_current();
+        gl::flush();
+    }
+
+    pub fn make_current(&self) {
+        self.platform_context.make_current();
+    }
+
+    pub fn drop_current_context(&self) {
+        self.platform_context.drop_current_context();
+    }
+}

--- a/src/gl_context_android.rs
+++ b/src/gl_context_android.rs
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2015 The Servo Project Developers
+ *
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
+use euclid::size::Size2D;
+use egl::egl;
+use std::ptr;
+
+pub struct PlatformDisplayData {
+    pub display: egl::EGLDisplay,
+}
+
+pub struct GLPlatformContext {
+    pub display: egl::EGLDisplay,
+    pub egl_context: egl::EGLContext,
+    egl_surface: egl::EGLSurface,
+}
+
+impl Drop for GLPlatformContext {
+    fn drop(&mut self) {
+        self.drop_current_context();
+        egl::DestroyContext(self.display, self.egl_context);
+        egl::DestroySurface(self.display, self.egl_surface);
+    }
+}
+
+impl GLPlatformContext {
+    pub fn new(platform_display_data: PlatformDisplayData,
+               size: Size2D<i32>)
+               -> Option<GLPlatformContext> {
+        let config_attributes = [
+            egl::EGL_SURFACE_TYPE as i32, egl::EGL_PBUFFER_BIT as i32,
+            egl::EGL_RENDERABLE_TYPE as i32, egl::EGL_OPENGL_ES2_BIT as i32,
+            egl::EGL_RED_SIZE as i32, 8,
+            egl::EGL_BLUE_SIZE as i32, 8,
+            egl::EGL_ALPHA_SIZE as i32, 8,
+            egl::EGL_NONE as i32,
+        ];
+
+        let display = platform_display_data.display;
+        let mut surface_config = ptr::null_mut();
+        let mut number_of_configs = 0;
+        egl::ChooseConfig(display,
+                          config_attributes.as_ptr(),
+                          &mut surface_config, 1, &mut number_of_configs);
+        if number_of_configs == 0 {
+            return None;
+        }
+
+        let context_attributes = [
+            egl::EGL_CONTEXT_CLIENT_VERSION as i32, 2,
+            egl::EGL_NONE as i32
+        ];
+        let egl_context = egl::CreateContext(display,
+                                             surface_config,
+                                             egl::EGL_NO_CONTEXT as egl::EGLContext,
+                                             context_attributes.as_ptr());
+        if egl_context == egl::EGL_NO_CONTEXT as egl::EGLContext {
+            return None;
+        }
+
+        let mut surface_attributes = [
+            egl::EGL_WIDTH as i32, size.width,
+            egl::EGL_HEIGHT as i32, size.height,
+            egl::EGL_NONE as i32,
+        ];
+        let egl_surface = egl::CreatePbufferSurface(display,
+                                                    surface_config,
+                                                    &mut surface_attributes[0]);
+        if egl_surface == egl::EGL_NO_SURFACE as egl::EGLSurface {
+            egl::DestroyContext(display, egl_context);
+            return None;
+        }
+
+
+        Some(GLPlatformContext {
+            display: display,
+            egl_context: egl_context,
+            egl_surface: egl_surface,
+        })
+    }
+
+    pub fn drop_current_context(&self) {
+        egl::MakeCurrent(self.display, ptr::null_mut(), ptr::null_mut(), ptr::null_mut());
+    }
+
+    pub fn make_current(&self) {
+        egl::MakeCurrent(self.display, self.egl_surface, self.egl_surface, self.egl_context);
+    }
+}

--- a/src/gl_context_cgl.rs
+++ b/src/gl_context_cgl.rs
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2015 The Servo Project Developers
+ *
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
+use euclid::size::Size2D;
+use cgl;
+use gleam::gl;
+use std::ptr;
+
+pub struct PlatformDisplayData {
+    pub pixel_format: cgl::CGLPixelFormatObj,
+}
+
+pub struct GLPlatformContext {
+    pub cgl_context: cgl::CGLContextObj,
+}
+
+impl Drop for GLPlatformContext {
+    fn drop(&mut self) {
+        unsafe {
+            cgl::CGLDestroyContext(self.cgl_context);
+        }
+    }
+}
+
+impl GLPlatformContext {
+    pub fn new(platform_display_data: PlatformDisplayData,
+               _: Size2D<i32>)
+               -> Option<GLPlatformContext> {
+        unsafe {
+            let mut cgl_context = ptr::null_mut();
+            let _ = cgl::CGLCreateContext(platform_display_data.pixel_format,
+                                          ptr::null_mut(),
+                                          &mut cgl_context);
+            if ptr::null_mut() == cgl_context {
+                return None;
+            }
+
+            cgl::CGLSetCurrentContext(cgl_context);
+            gl::enable(gl::TEXTURE_RECTANGLE_ARB);
+
+            Some(GLPlatformContext {
+                cgl_context: cgl_context,
+            })
+        }
+    }
+
+    pub fn drop_current_context(&self) {
+        unsafe {
+            cgl::CGLSetCurrentContext(ptr::null_mut());
+        }
+    }
+
+    pub fn make_current(&self) {
+        unsafe {
+            cgl::CGLSetCurrentContext(self.cgl_context);
+        }
+    }
+}

--- a/src/gl_context_glx.rs
+++ b/src/gl_context_glx.rs
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2015 The Servo Project Developers
+ *
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
+use euclid::size::Size2D;
+use glx;
+use std::ptr;
+use x11::xlib;
+
+pub struct PlatformDisplayData {
+    pub display: *mut xlib::Display,
+    pub visual_info: *mut xlib::XVisualInfo,
+}
+
+pub struct GLPlatformContext {
+    pub display: *mut xlib::Display,
+    glx_context: xlib::XID,
+    pub glx_pixmap: xlib::XID,
+    pub pixmap: xlib::XID,
+}
+
+impl Drop for GLPlatformContext {
+    fn drop(&mut self) {
+        // We need this thread to grab the GLX context before we can make
+        // OpenGL calls. But glXMakeCurrent() will flush the old context,
+        // which might have been uninitialized. Dropping the current context
+        // first solves this problem somehow.
+        self.drop_current_context();
+        self.make_current();
+
+        unsafe {
+            let glx_display = self.display as *mut glx::types::Display;
+            glx::MakeCurrent(glx_display, 0 /* None */, ptr::null_mut());
+            glx::DestroyContext(glx_display, self.glx_context as glx::types::GLXContext);
+            glx::DestroyGLXPixmap(glx_display, self.glx_pixmap);
+            xlib::XFreePixmap(self.display, self.pixmap);
+        }
+    }
+}
+
+impl GLPlatformContext {
+    pub fn new(platform_display_data: PlatformDisplayData,
+               size: Size2D<i32>)
+               -> Option<GLPlatformContext> {
+        unsafe {
+            let display = platform_display_data.display;
+            let visual_info = platform_display_data.visual_info;
+            let glx_display = display as *mut glx::types::Display;
+            let glx_visual_info = visual_info as *mut glx::types::XVisualInfo;
+
+            let root_window = xlib::XRootWindow(display, xlib::XDefaultScreen(display));
+            let pixmap = xlib::XCreatePixmap(display,
+                                             root_window,
+                                             size.width as u32,
+                                             size.height as u32,
+                                             (*visual_info).depth as u32);
+            let glx_pixmap = glx::CreateGLXPixmap(glx_display,
+                                                  glx_visual_info,
+                                                  pixmap);
+
+            let glx_context = glx::CreateContext(glx_display,
+                                                 glx_visual_info,
+                                                 ptr::null_mut(),
+                                                 1);
+
+            if glx_context == ptr::null() {
+                glx::DestroyGLXPixmap(glx_display, glx_pixmap);
+                return None;
+            }
+
+            Some(GLPlatformContext {
+                display: display,
+                glx_context: glx_context as xlib::XID,
+                pixmap: pixmap,
+                glx_pixmap: glx_pixmap as xlib::XID,
+            })
+        }
+    }
+
+    pub fn drop_current_context(&self) {
+        unsafe {
+            glx::MakeCurrent(self.display as *mut glx::types::Display,
+                             0 /* None */,
+                             ptr::null_mut());
+        }
+    }
+
+    pub fn make_current(&self) {
+        unsafe {
+            glx::MakeCurrent(self.display as *mut glx::types::Display,
+                             self.glx_pixmap,
+                             self.glx_context as glx::types::GLXContext);
+        }
+    }
+}

--- a/src/gl_rasterization_context_android.rs
+++ b/src/gl_rasterization_context_android.rs
@@ -5,136 +5,75 @@
  * found in the LICENSE file.
  */
 
+use gl_context::GLContext;
 use gl_rasterization_context;
-use skia;
 
 use euclid::size::Size2D;
 use egl::egl;
 use egl::eglext;
 use gleam::gl;
-use std::ffi::CString;
-use std::ptr;
+use std::sync::Arc;
 
 pub struct GLRasterizationContext {
-    display: egl::EGLDisplay,
-    egl_context: egl::EGLContext,
-    egl_surface: egl::EGLSurface,
+    pub gl_context: Arc<GLContext>,
     pub egl_image: eglext::EGLImageKHR,
     pub size: Size2D<i32>,
-
     pub framebuffer_id: gl::GLuint,
     texture_id: gl::GLuint,
     depth_stencil_renderbuffer_id: gl::GLuint,
-    pub gr_context: skia::SkiaGrContextRef,
 }
 
 impl Drop for GLRasterizationContext {
     fn drop(&mut self) {
         self.make_current();
 
-        gl_rasterization_context::destroy_framebuffer(self.gr_context,
-                                                      self.framebuffer_id,
+        gl_rasterization_context::destroy_framebuffer(self.framebuffer_id,
                                                       self.texture_id,
                                                       self.depth_stencil_renderbuffer_id);
-
-        self.drop_current_context();
-        egl::DestroyContext(self.display, self.egl_context);
-        egl::DestroySurface(self.display, self.egl_surface);
     }
 }
 
 impl GLRasterizationContext {
-    pub fn new(display: egl::EGLDisplay,
+    pub fn new(gl_context: Arc<GLContext>,
                size: Size2D<i32>)
                -> Option<GLRasterizationContext> {
-        unsafe {
-            let config_attributes = [
-                egl::EGL_SURFACE_TYPE as i32, egl::EGL_PBUFFER_BIT as i32,
-                egl::EGL_RENDERABLE_TYPE as i32, egl::EGL_OPENGL_ES2_BIT as i32,
-                egl::EGL_RED_SIZE as i32, 8,
-                egl::EGL_BLUE_SIZE as i32, 8,
-                egl::EGL_ALPHA_SIZE as i32, 8,
-                egl::EGL_NONE as i32,
-            ];
+        gl_context.make_current();
 
-            let mut surface_config = ptr::null_mut();
-            let mut number_of_configs = 0;
-            egl::ChooseConfig(display, config_attributes.as_ptr(),
-                              &mut surface_config, 1, &mut number_of_configs);
-            if number_of_configs == 0 {
-                return None;
-            }
-
-            let context_attributes = [
-                egl::EGL_CONTEXT_CLIENT_VERSION as i32, 2,
-                egl::EGL_NONE as i32
-            ];
-            let egl_context = egl::CreateContext(display,
-                                                 surface_config,
-                                                 egl::EGL_NO_CONTEXT as egl::EGLContext,
-                                                 context_attributes.as_ptr());
-            if egl_context == egl::EGL_NO_CONTEXT as egl::EGLContext {
-                return None;
-            }
-
-            let mut surface_attributes = [
-                egl::EGL_WIDTH as i32, size.width,
-                egl::EGL_HEIGHT as i32, size.height,
-                egl::EGL_NONE as i32,
-            ];
-            let egl_surface = egl::CreatePbufferSurface(display,
-                                                        surface_config,
-                                                        &mut surface_attributes[0]);
-            if egl_surface == egl::EGL_NO_SURFACE as egl::EGLSurface {
-                egl::DestroyContext(display, egl_context);
-                return None;
-            }
-
-            let (framebuffer_id, texture_id, depth_stencil_renderbuffer_id, gr_context) =
-                gl_rasterization_context::setup_framebuffer(gl::TEXTURE_2D, size, || {
-                    gl::tex_image_2d(gl::TEXTURE_2D, 0,
-                                     gl::RGBA as gl::GLint,
-                                     size.width, size.height, 0,
-                                     gl::RGBA, gl::UNSIGNED_BYTE, None);
-                });
-
-            if gr_context == ptr::null_mut() {
-                egl::MakeCurrent(display, ptr::null_mut(), ptr::null_mut(), ptr::null_mut());
-                egl::DestroyContext(display, egl_context);
-                egl::DestroySurface(display, egl_surface);
-                return None;
-            }
-
+        if let Some((framebuffer_id, texture_id, depth_stencil_renderbuffer_id)) =
+            gl_rasterization_context::setup_framebuffer(gl::TEXTURE_2D,
+                                                        size,
+                                                        gl_context.gl_interface,
+                                                        || {
+            gl::tex_image_2d(gl::TEXTURE_2D, 0,
+                             gl::RGBA as gl::GLint,
+                             size.width, size.height, 0,
+                             gl::RGBA, gl::UNSIGNED_BYTE, None);
+        }) {
             let egl_image_attributes = [
                 eglext::EGL_IMAGE_PRESERVED_KHR as i32, egl::EGL_TRUE as i32,
                 egl::EGL_NONE as i32, egl::EGL_NONE as i32,
             ];
-            let egl_image = eglext::CreateImageKHR(display,
-                                                   egl_context,
+            let egl_image = eglext::CreateImageKHR(gl_context.platform_context.display,
+                                                   gl_context.platform_context.egl_context,
                                                    eglext::EGL_GL_TEXTURE_2D_KHR,
                                                    texture_id as egl::EGLClientBuffer,
                                                    egl_image_attributes.as_ptr());
 
-            Some(GLRasterizationContext {
-                display: display,
-                egl_context: egl_context,
-                egl_surface: egl_surface,
+            return Some(GLRasterizationContext {
+                gl_context: gl_context,
                 egl_image: egl_image,
                 size: size,
                 framebuffer_id: framebuffer_id,
                 texture_id: texture_id,
                 depth_stencil_renderbuffer_id: depth_stencil_renderbuffer_id,
-                gr_context: gr_context,
-            })
+            });
         }
-    }
 
-    pub fn drop_current_context(&self) {
-        egl::MakeCurrent(self.display, ptr::null_mut(), ptr::null_mut(), ptr::null_mut());
+        None
     }
 
     pub fn make_current(&self) {
-        egl::MakeCurrent(self.display, self.egl_surface, self.egl_surface, self.egl_context);
+        self.gl_context.make_current();
     }
 
     pub fn flush(&self) {

--- a/src/gl_rasterization_context_cgl.rs
+++ b/src/gl_rasterization_context_cgl.rs
@@ -5,86 +5,68 @@
  * found in the LICENSE file.
  */
 
+use gl_context::GLContext;
 use gl_rasterization_context;
-use skia;
 
 use cgl;
 use euclid::size::Size2D;
 use gleam::gl;
 use io_surface;
 use libc;
-use std::ptr;
+use std::sync::Arc;
 
 pub struct GLRasterizationContext {
-    cgl_context: cgl::CGLContextObj,
+    pub gl_context: Arc<GLContext>,
     pub size: Size2D<i32>,
-
     pub framebuffer_id: gl::GLuint,
     texture_id: gl::GLuint,
     depth_stencil_renderbuffer_id: gl::GLuint,
-    pub gr_context: skia::SkiaGrContextRef,
 }
 
 impl Drop for GLRasterizationContext {
     fn drop(&mut self) {
         self.make_current();
-        gl_rasterization_context::destroy_framebuffer(self.gr_context,
-                                                      self.framebuffer_id,
+        gl_rasterization_context::destroy_framebuffer(self.framebuffer_id,
                                                       self.texture_id,
                                                       self.depth_stencil_renderbuffer_id);
-        unsafe {
-            cgl::CGLDestroyContext(self.cgl_context);
-        }
     }
 }
 
 impl GLRasterizationContext {
-    pub fn new(pixel_format: cgl::CGLPixelFormatObj,
+    pub fn new(gl_context: Arc<GLContext>,
                io_surface: io_surface::IOSurfaceRef,
                size: Size2D<i32>)
                -> Option<GLRasterizationContext> {
-        unsafe {
-            let mut cgl_context = ptr::null_mut();
-            let _ = cgl::CGLCreateContext(pixel_format, ptr::null_mut(), &mut cgl_context);
-            if ptr::null_mut() == cgl_context {
-                return None;
+        gl_context.make_current();
+
+        if let Some((framebuffer_id, texture_id, depth_stencil_renderbuffer_id)) =
+            gl_rasterization_context::setup_framebuffer(gl::TEXTURE_RECTANGLE_ARB,
+                                                        size,
+                                                        gl_context.gl_interface,
+                                                        || {
+            unsafe {
+                cgl::CGLTexImageIOSurface2D(gl_context.platform_context.cgl_context,
+                                            gl::TEXTURE_RECTANGLE_ARB, gl::RGBA,
+                                            size.width, size.height,
+                                            gl::BGRA, gl::UNSIGNED_INT_8_8_8_8_REV,
+                                            io_surface as *mut libc::c_void,
+                                            0);
             }
-
-            // The Skia GL interface needs to be created while the context is active, so we
-            // do that immediately after setting the context as the current one.
-            cgl::CGLSetCurrentContext(cgl_context);
-            gl::enable(gl::TEXTURE_RECTANGLE_ARB);
-
-            let (framebuffer_id, texture_id, depth_stencil_renderbuffer_id, gr_context) =
-                gl_rasterization_context::setup_framebuffer(gl::TEXTURE_RECTANGLE_ARB, size, || {
-                    cgl::CGLTexImageIOSurface2D(cgl_context,
-                                                gl::TEXTURE_RECTANGLE_ARB, gl::RGBA,
-                                                size.width, size.height,
-                                                gl::BGRA, gl::UNSIGNED_INT_8_8_8_8_REV,
-                                                io_surface as *mut libc::c_void,
-                                                0);
-                });
-
-            if gr_context == ptr::null_mut() {
-                cgl::CGLDestroyContext(cgl_context);
-                return None;
-            }
-
-            Some(GLRasterizationContext {
-                cgl_context: cgl_context,
+        }) {
+            return Some(GLRasterizationContext {
+                gl_context: gl_context,
                 size: size,
                 framebuffer_id: framebuffer_id,
                 texture_id: texture_id,
                 depth_stencil_renderbuffer_id: depth_stencil_renderbuffer_id,
-                gr_context: gr_context,
-            })
+            });
         }
+
+        None
     }
 
     pub fn make_current(&self) {
-        unsafe {
-            cgl::CGLSetCurrentContext(self.cgl_context);
-        }
+        self.gl_context.make_current();
     }
 
     pub fn flush(&self) {

--- a/src/gl_rasterization_context_glx.rs
+++ b/src/gl_rasterization_context_glx.rs
@@ -5,119 +5,66 @@
  * found in the LICENSE file.
  */
 
+use gl_context::GLContext;
 use gl_rasterization_context;
-use skia;
 
 use euclid::size::Size2D;
 use gleam::gl;
-use glx;
 use std::ptr;
+use std::sync::Arc;
 use x11::xlib;
 
 pub struct GLRasterizationContext {
-    display: *const xlib::Display,
-    glx_context: xlib::XID,
-    glx_pixmap: xlib::XID,
+    pub gl_context: Arc<GLContext>,
     pub size: Size2D<i32>,
-
     pub framebuffer_id: gl::GLuint,
+    pixmap: xlib::XID,
     texture_id: gl::GLuint,
     depth_stencil_renderbuffer_id: gl::GLuint,
-    pub gr_context: skia::SkiaGrContextRef,
 }
 
 impl Drop for GLRasterizationContext {
     fn drop(&mut self) {
-        // We need this thread to grab the GLX context before we can make
-        // OpenGL calls. But glXMakeCurrent() will flush the old context,
-        // which might have been uninitialized. Dropping the current context
-        // first solves this problem somehow.
-        self.drop_current_context();
-        self.make_current();
-
-        gl_rasterization_context::destroy_framebuffer(self.gr_context,
-                                                      self.framebuffer_id,
+        self.gl_context.make_current();
+        gl_rasterization_context::destroy_framebuffer(self.framebuffer_id,
                                                       self.texture_id,
                                                       self.depth_stencil_renderbuffer_id);
 
-        unsafe {
-            let glx_display = self.display as *mut glx::types::Display;
-            glx::MakeCurrent(glx_display, 0 /* None */, ptr::null_mut());
-            glx::DestroyContext(glx_display, self.glx_context as glx::types::GLXContext);
-            glx::DestroyGLXPixmap(glx_display, self.glx_pixmap);
-        }
     }
 }
 
 impl GLRasterizationContext {
-    pub fn new(display: *mut xlib::Display,
-               visual_info: *mut xlib::XVisualInfo,
+    pub fn new(gl_context: Arc<GLContext>,
                pixmap: xlib::Pixmap,
                size: Size2D<i32>)
                -> Option<GLRasterizationContext> {
-        unsafe {
-            let glx_display = display as *mut glx::types::Display;
-            let glx_visual_info = visual_info as *mut glx::types::XVisualInfo;
-            let glx_pixmap = glx::CreateGLXPixmap(glx_display,
-                                                  glx_visual_info,
-                                                  pixmap);
+        gl_context.make_current();
 
-            let glx_context = glx::CreateContext(glx_display,
-                                                 glx_visual_info,
-                                                 ptr::null_mut(),
-                                                 1);
-
-            if glx_context == ptr::null() {
-                glx::DestroyGLXPixmap(glx_display, glx_pixmap);
-                return None;
-            }
-
-            // The Skia GL interface needs to be created while the context is active, so we
-            // do that immediately after setting the context as the current one.
-            glx::MakeCurrent(glx_display, glx_pixmap, glx_context);
-
-            let (framebuffer_id, texture_id, depth_stencil_renderbuffer_id, gr_context) =
-                gl_rasterization_context::setup_framebuffer(gl::TEXTURE_2D, size, || {
-                    gl::tex_image_2d(gl::TEXTURE_2D, 0,
-                                     gl::RGBA as gl::GLint,
-                                     size.width, size.height, 0,
-                                     gl::RGBA, gl::UNSIGNED_BYTE, None);
-                });
-
-            if gr_context == ptr::null_mut() {
-                glx::MakeCurrent(glx_display, 0 /* None */, ptr::null_mut());
-                glx::DestroyContext(glx_display, glx_context);
-                glx::DestroyGLXPixmap(glx_display, glx_pixmap);
-                return None;
-            }
-
-            Some(GLRasterizationContext {
-                display: display,
-                glx_context: glx_context as xlib::XID,
-                glx_pixmap: glx_pixmap as xlib::XID,
+        if let Some((framebuffer_id, texture_id, depth_stencil_renderbuffer_id)) =
+            gl_rasterization_context::setup_framebuffer(gl::TEXTURE_2D,
+                                                        size,
+                                                        gl_context.gl_interface,
+                                                        || {
+            gl::tex_image_2d(gl::TEXTURE_2D, 0,
+                             gl::RGBA as gl::GLint,
+                             size.width, size.height, 0,
+                             gl::RGBA, gl::UNSIGNED_BYTE, None);
+        }) {
+            return Some(GLRasterizationContext {
+                gl_context: gl_context,
                 size: size,
+                pixmap: pixmap,
                 framebuffer_id: framebuffer_id,
                 texture_id: texture_id,
                 depth_stencil_renderbuffer_id: depth_stencil_renderbuffer_id,
-                gr_context: gr_context,
-            })
+            });
         }
-    }
 
-    pub fn drop_current_context(&self) {
-        unsafe {
-            glx::MakeCurrent(self.display as *mut glx::types::Display,
-                             0 /* None */,
-                             ptr::null_mut());
-        }
+        None
     }
 
     pub fn make_current(&self) {
-        unsafe {
-            glx::MakeCurrent(self.display as *mut glx::types::Display,
-                             self.glx_pixmap,
-                             self.glx_context as glx::types::GLXContext);
-        }
+        self.gl_context.make_current();
     }
 
     pub fn flush(&self) {
@@ -137,7 +84,23 @@ impl GLRasterizationContext {
                                 gl::COLOR_BUFFER_BIT, gl::NEAREST);
         }
 
-        gl::flush();
-        gl::bind_framebuffer(gl::FRAMEBUFFER, 0);
+        gl::finish();
+        self.gl_context.drop_current_context();
+
+        // Since the GLRasterizationContext renders to a Pixmap that is owned by the
+        // GLContext, we now need to copy the results to the target Pixmap. This means
+        // we do an extra hardware copy, but allows us to reuse the same GLContext.
+        let display = self.gl_context.platform_context.display;
+        let source_pixmap = self.gl_context.platform_context.pixmap;
+        unsafe {
+            let gc = xlib::XCreateGC(display, self.pixmap, 0, ptr::null_mut());
+            xlib::XCopyArea(display, source_pixmap,
+                            self.pixmap,
+                            gc,
+                            0, (self.gl_context.size.height - self.size.height),
+                            self.size.width as u32, self.size.height as u32,
+                            0, 0);
+            xlib::XFreeGC(display, gc);
+        }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,15 +33,22 @@ pub use skia::{
 };
 
 pub mod linkhack;
+pub mod gl_context;
 pub mod gl_rasterization_context;
 pub mod skia;
 
 #[cfg(target_os="linux")]
+pub mod gl_context_glx;
+#[cfg(target_os="linux")]
 pub mod gl_rasterization_context_glx;
 
 #[cfg(target_os="macos")]
+pub mod gl_context_cgl;
+#[cfg(target_os="macos")]
 pub mod gl_rasterization_context_cgl;
 
+#[cfg(target_os="android")]
+pub mod gl_context_android;
 #[cfg(target_os="android")]
 pub mod gl_rasterization_context_android;
 


### PR DESCRIPTION
This will allow Servo to preserve the same GLContext and GrContext
between rasterization targets, thus vastly improving the performance of
OpenGL rasterization.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/skia/60)
<!-- Reviewable:end -->
