### PR TITLE
Preserve framebuffers between GLRasterizationContexts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,6 @@
 sudo: false
 language: rust
-
-# We pin rust here, because aster (0.3.3) is broken with the latest
-# rust nightly. Once aster is fixed we can change this back to 'nightly.'
-rust: nightly-2015-07-10
-
+rust: nightly
 branches:
   except:
     - master

--- a/src/gl_context.rs
+++ b/src/gl_context.rs
@@ -21,6 +21,8 @@ pub use gl_context_cgl::PlatformDisplayData;
 pub use gl_context_glx::GLPlatformContext;
 #[cfg(target_os="linux")]
 pub use gl_context_glx::PlatformDisplayData;
+#[cfg(target_os="linux")]
+pub use gl_rasterization_context::GLRasterizationContext;
 
 #[cfg(target_os="android")]
 pub use gl_context_android::GLPlatformContext;

--- a/src/gl_context_cgl.rs
+++ b/src/gl_context_cgl.rs
@@ -5,6 +5,9 @@
  * found in the LICENSE file.
  */
 
+use gl_rasterization_context;
+use skia;
+
 use euclid::size::Size2D;
 use cgl;
 use gleam::gl;
@@ -16,10 +19,19 @@ pub struct PlatformDisplayData {
 
 pub struct GLPlatformContext {
     pub cgl_context: cgl::CGLContextObj,
+
+    pub framebuffer_id: gl::GLuint,
+    texture_id: gl::GLuint,
+    depth_stencil_renderbuffer_id: gl::GLuint,
 }
 
 impl Drop for GLPlatformContext {
     fn drop(&mut self) {
+        self.make_current();
+        gl_rasterization_context::destroy_framebuffer(self.framebuffer_id,
+                                                      self.texture_id,
+                                                      self.depth_stencil_renderbuffer_id);
+
         unsafe {
             cgl::CGLDestroyContext(self.cgl_context);
         }
@@ -28,7 +40,7 @@ impl Drop for GLPlatformContext {
 
 impl GLPlatformContext {
     pub fn new(platform_display_data: PlatformDisplayData,
-               _: Size2D<i32>)
+               size: Size2D<i32>)
                -> Option<GLPlatformContext> {
         unsafe {
             let mut cgl_context = ptr::null_mut();
@@ -42,8 +54,25 @@ impl GLPlatformContext {
             cgl::CGLSetCurrentContext(cgl_context);
             gl::enable(gl::TEXTURE_RECTANGLE_ARB);
 
+            let gl_interface = skia::SkiaGrGLCreateNativeInterface();
+            if gl_interface == ptr::null_mut() {
+                cgl::CGLDestroyContext(cgl_context);
+                return None
+            }
+
+            // We only start the framebuffer setup here, since we cannot complete it until
+            // we have a texture image. That will be provided by the IOSurface in the
+            // GLRasterizationContext.
+            let (framebuffer_id, texture_id, depth_stencil_renderbuffer_id) =
+                gl_rasterization_context::start_framebuffer_setup(gl::TEXTURE_RECTANGLE_ARB,
+                                                                  size,
+                                                                  gl_interface);
+            skia::SkiaGrGLInterfaceRelease(gl_interface);
             Some(GLPlatformContext {
                 cgl_context: cgl_context,
+                framebuffer_id: framebuffer_id,
+                texture_id: texture_id,
+                depth_stencil_renderbuffer_id: depth_stencil_renderbuffer_id,
             })
         }
     }


### PR DESCRIPTION
Reuse the same framebuffer when creating GLRasterizationContexts. This
leads to another large overhead decrease, but means that we can only
create one GLRasterizationContext at a time.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/skia/63)
<!-- Reviewable:end -->
