### PR TITLE
Add missing encoder to makefile.cargo

### DIFF
--- a/makefile.cargo
+++ b/makefile.cargo
@@ -43,6 +43,8 @@ CXXFLAGS += \
 	-Iinclude/utils \
 	-Isrc/core \
 	-Isrc/image \
+	-Isrc/images \
+	-Isrc/lazy \
 	-Isrc/opts \
 	-Isrc/ports \
 	-Isrc/sfnt \
@@ -564,6 +566,13 @@ SKIA_GL_CXX_SRC += \
 		gl/android/SkNativeGLContext_android.cpp \
 	)
 
+SKIA_IMAGES_CXX_SRC += \
+	$(addprefix src/images/,\
+		SkImageEncoder.cpp \
+		SkImageEncoder_Factory.cpp \
+		SkImageEncoder_argb.cpp \
+	)
+
 SKIA_PORTS_CXX_SRC = \
 	$(addprefix src/ports/,\
 		SkDebug_android.cpp \
@@ -626,6 +635,7 @@ SKIA_SRC = \
 	$(SKIA_FONTS_CXX_SRC) \
 	$(SKIA_GL_CXX_SRC) \
 	$(SKIA_IMAGE_CXX_SRC) \
+	$(SKIA_IMAGES_CXX_SRC) \
 	$(SKIA_PATHOPS_CXX_SRC) \
 	$(SKIA_PORTS_CXX_SRC) \
 	$(SKIA_SFNT_CXX_SRC) \


### PR DESCRIPTION
r? @metajack @glennw 

The missing encoder symbol definition was breaking android load while I've been switching our linker invocation ever-so-slightly.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/skia/67)
<!-- Reviewable:end -->
