### PR TITLE
Exclude a bunch of things from `cargo package`.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,13 @@ version = "0.0.20130412"
 authors = ["The Skia Project Developers and The Servo Project Developers"]
 links = "skia"
 build = "build.rs"
+exclude = [
+    "experimental/*", 
+    "expectations/*", 
+    "platform_tools/*", 
+    "tools/*",
+    "tests/*",
+]
 
 [dependencies]
 euclid = "0.2"


### PR DESCRIPTION
Having servo fetch skia from crates.io would help with issues like #7687, as the compressed crate is 12 MB rather than 330 MB of git history. It’s still over the 10 MB limit of crates.io, though.

This excludes some of the repository’s directory from the archive created by `cargo package` to bring it to 5 MB, while the "Verifying" phase (running `cargo build` from sources extracted again from the archive)
still succeeds.

Before we can publish skia we still need to publish all the recursive dependencies.

r? @mrobinson

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/skia/73)
<!-- Reviewable:end -->
