### PR TITLE
remove SkBitmapHasher.cpp from build

### DIFF
--- a/makefile.cargo
+++ b/makefile.cargo
@@ -483,7 +483,6 @@ SKIA_SFNT_CXX_SRC = \
 SKIA_UTILS_CXX_SRC = \
 	$(addprefix src/utils/,\
 		SkBase64.cpp \
-		SkBitmapHasher.cpp \
 		SkBitSet.cpp \
 		SkBoundaryPatch.cpp \
 		SkCamera.cpp \


### PR DESCRIPTION
this contains undefined symbol references and is never used

ref servo #8883

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/skia/84)
<!-- Reviewable:end -->
