### PR TITLE
Exclude more directories in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "servo-skia"
-version = "0.20130412.6"
+version = "0.20130412.7"
 authors = ["The Skia Project Developers and The Servo Project Developers"]
 description = "2D graphic library for drawing Text, Geometries, and Images"
 license = "BSD-3-Clause"
@@ -12,7 +12,11 @@ build = "build.rs"
 exclude = [
     "experimental/*",
     "expectations/*",
+    "gm/tests/*",
+    "gm/rebaseline_server/*",
     "platform_tools/android/bin/*",
+    "platform_tools/android/examples/*",
+    "platform_tools/android/tests/*",
     "tools/*",
     "tests/*",
 ]


### PR DESCRIPTION
This doesn’t significantly affect the size of tarballs, but make them not include some files with very long paths like

```
gm/rebaseline_server/testdata/outputs/expected/compare_rendered_pictures_test.CompareRenderedPicturesTest.test_endToEnd/compare_rendered_pictures.json
```

This will hopefully help on Windows:

http://logs.glob.uno/?c=mozilla%23servo#c403696
https://i.imgur.com/JeBRLlE.png
https://github.com/rust-lang/cargo/issues/2516
http://logs.glob.uno/?c=mozilla%23servo#c403699

The longest path from the crate root is now 65, down from 150.

```
third_party/freetype/include_overrides/freetype/config/ftoption.h
```

I’ve checked that `cargo build --target arm-linux-androideabi` still succeeds when run on the result of extracting the tarball.

r? @mbrubeck

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/skia/91)
<!-- Reviewable:end -->
