### PR TITLE
Really bump version number

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "servo-skia"
-version = "0.20130412.13"
+version = "0.20130412.14"
 authors = ["The Skia Project Developers and The Servo Project Developers"]
 description = "2D graphic library for drawing Text, Geometries, and Images"
 license = "BSD-3-Clause"


### PR DESCRIPTION
The version number bump got lost in the merge, thus making it impossible for rust-azure to pick up a proper version.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/skia/106)
<!-- Reviewable:end -->
