### PR TITLE
Support armv7-linux-androideabi && aarch64-linux-android targets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -636,7 +636,7 @@ endif() # Windows
 
 message(STATUS "Building for target: $ENV{TARGET}")
 
-if($ENV{TARGET} MATCHES ".*androideabi.*")
+if($ENV{TARGET} MATCHES ".*android.*")
   add_definitions(-DSK_BUILD_FOR_ANDROID -DEGL_EGLEXT_PROTOTYPES)
   include_directories(platform_tools/android/third_party/cpufeatures)
 
@@ -723,7 +723,7 @@ if($ENV{TARGET} MATCHES "(i686|x86_64)-.*")
       set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /arch:SSE2")
     endif()
   endif()
-elseif($ENV{TARGET} MATCHES "arm-.*")
+elseif($ENV{TARGET} MATCHES "(arm|armv7)-.*")
   set(SKIA_SRC ${SKIA_SRC} ${SKIA_OPTS_ARM_NEON_SRC})
   add_definitions(-mfpu=neon -D__ARM_HAVE_OPTIONAL_NEON_SUPPORT)
   # FIXME: Need more advanced detection of FP support

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "servo-skia"
-version = "0.30000004.1"
+version = "0.30000004.2"
 authors = ["The Skia Project Developers and The Servo Project Developers"]
 description = "2D graphic library for drawing Text, Geometries, and Images"
 license = "BSD-3-Clause"


### PR DESCRIPTION
Fixes:

- Linker error on Servo using `armv7-linux-androideabi` target
- Compilation error on Servo using `aarch64-linux-android` target

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/skia/136)
<!-- Reviewable:end -->
