### PR TITLE
Ios support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -566,7 +566,7 @@ if($ENV{TARGET} MATCHES ".*apple-ios")
 
   set_prefix(SKIA_UTILS_PLATFORM_SRC src/utils/iOS/
     SkImageDecoder_iOS.mm
-    SkStream_NSData.mm
+    SkStream_iOS.cpp
   )
   set_prefix( SKIA_IOS_STUB_SRC src/opts/
     SkMorphology_opts_none.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -541,8 +541,43 @@ set_prefix(SKIA_THIRDPARTY_SRC third_party/
   etc1/etc1.cpp
   ktx/ktx.cpp
   )
+if($ENV{TARGET} MATCHES ".*apple-ios")
+  add_definitions(-DSK_USE_POSIX_THREADS)
+  include_directories(include/utils/iOS)
+  include_directories(src/utils/iOS)
 
-if(APPLE)
+  set_prefix(SKIA_GL_PLATFORM_SRC src/gpu/gl/iOS/
+    GrGLCreateNativeInterface_iOS.cpp
+    SkNativeGLContext_iOS.mm
+  )
+
+  set_prefix(SKIA_PORTS_SRC src/ports/
+    SkDebug_stdio.cpp
+    SkFontHost_mac.cpp
+    SkGlobalInitialization_default.cpp
+    SkImageDecoder_empty.cpp
+    SkMemory_malloc.cpp
+    SkOSFile_posix.cpp
+    SkOSFile_stdio.cpp
+    SkTLS_pthread.cpp
+  )
+
+  set(SKIA_FONTS_SRC "")
+
+  set_prefix(SKIA_UTILS_PLATFORM_SRC src/utils/iOS/
+    SkImageDecoder_iOS.mm
+    SkStream_NSData.mm
+  )
+  set_prefix( SKIA_IOS_STUB_SRC src/opts/
+    SkMorphology_opts_none.cpp
+    SkBitmapProcState_opts_none.cpp
+    SkBlitMask_opts_none.cpp
+    SkBlitRow_opts_none.cpp
+    SkBlurImage_opts_none.cpp
+    SkUtils_opts_none.cpp
+    SkXfermode_opts_none.cpp
+  )
+elseif(APPLE)
   add_definitions(-DSK_USE_POSIX_THREADS)
   include_directories(include/utils/mac)
   include_directories(src/utils/mac)
@@ -711,7 +746,9 @@ set(SKIA_SRC
   ${SKIA_UTILS_PLATFORM_SRC}
   )
 
-if($ENV{TARGET} MATCHES "(i686|x86_64)-.*")
+if($ENV{TARGET} MATCHES ".*apple-ios")
+   set(SKIA_SRC ${SKIA_SRC} ${SKIA_IOS_STUB_SRC})
+elseif($ENV{TARGET} MATCHES "(i686|x86_64)-.*")
   set(SKIA_SRC ${SKIA_SRC} ${SKIA_OPTS_SSE2_SRC})
   set(SKIA_SRC ${SKIA_SRC} ${SKIA_OPTS_SSSE3_SRC})
   if(NOT MSVC)

--- a/include/utils/SkCGUtils.h
+++ b/include/utils/SkCGUtils.h
@@ -17,6 +17,7 @@
 
 #ifdef SK_BUILD_FOR_IOS
 #include <CoreGraphics/CoreGraphics.h>
+#include <MobileCoreServices/MobileCoreServices.h>
 #endif
 
 class SkBitmap;

--- a/src/gl_context.rs
+++ b/src/gl_context.rs
@@ -18,6 +18,11 @@ pub use gl_context_cgl::GLPlatformContext;
 #[cfg(target_os="macos")]
 pub use gl_context_cgl::PlatformDisplayData;
 
+#[cfg(target_os="ios")]
+pub use gl_context_ios::GLPlatformContext;
+#[cfg(target_os="ios")]
+pub use gl_context_ios::PlatformDisplayData;
+
 #[cfg(target_os="linux")]
 pub use gl_context_glx::GLPlatformContext;
 #[cfg(target_os="linux")]

--- a/src/gl_context_ios.rs
+++ b/src/gl_context_ios.rs
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2015 The Servo Project Developers
+ *
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+use euclid::Size2D;
+use gleam::gl;
+use std::rc::Rc;
+
+pub struct PlatformDisplayData {
+}
+
+pub struct GLPlatformContext {
+}
+
+impl Drop for GLPlatformContext {
+    fn drop(&mut self) {
+        self.drop_current_context();
+    }
+}
+
+impl GLPlatformContext {
+    pub fn new(_: Rc<gl::Gl>,
+               _platform_display_data: PlatformDisplayData,
+               _size: Size2D<i32>)
+               -> Option<GLPlatformContext> {
+        None
+    }
+
+    pub fn drop_current_context(&self) {
+        unimplemented!();
+    }
+
+    pub fn make_current(&self) {
+        unimplemented!();
+    }
+}

--- a/src/gl_rasterization_context_ios.rs
+++ b/src/gl_rasterization_context_ios.rs
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2013, 2015 The Servo Project Developers
+ *
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
+use gl_context::GLContext;
+
+use euclid::Size2D;
+use std::sync::Arc;
+
+pub struct GLRasterizationContext {
+    pub gl_context: Arc<GLContext>,
+}
+
+impl Drop for GLRasterizationContext {
+    fn drop(&mut self) {
+    }
+}
+
+impl GLRasterizationContext {
+    pub fn new(_gl_context: Arc<GLContext>,
+               _size: Size2D<i32>)
+               -> Option<GLRasterizationContext> {
+        None
+    }
+
+    pub fn make_current(&self) {
+        unimplemented!();
+    }
+
+    pub fn flush(&self) {
+        unimplemented!();
+    }
+
+    pub fn flush_to_surface(&self) {
+        unimplemented!();
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,6 +52,11 @@ pub mod gl_context_cgl;
 #[cfg(target_os="macos")]
 pub mod gl_rasterization_context_cgl;
 
+#[cfg(target_os="ios")]
+pub mod gl_context_ios;
+#[cfg(target_os="ios")]
+pub mod gl_rasterization_context_ios;
+
 #[cfg(target_os="android")]
 pub mod gl_context_android;
 #[cfg(target_os="android")]

--- a/src/utils/ios/SkStream_iOS.cpp
+++ b/src/utils/ios/SkStream_iOS.cpp
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2012 Google Inc.
+ *
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
+#include "SkCGUtils.h"
+#include "SkStream.h"
+
+// This is used by CGDataProviderCreateWithData
+
+static void unref_proc(void* info, const void* addr, size_t size) {
+    SkASSERT(info);
+    ((SkRefCnt*)info)->unref();
+}
+
+// These are used by CGDataProviderSequentialCallbacks
+
+static size_t get_bytes_proc(void* info, void* buffer, size_t bytes) {
+    SkASSERT(info);
+    return ((SkStream*)info)->read(buffer, bytes);
+}
+
+static off_t skip_forward_proc(void* info, off_t bytes) {
+    return ((SkStream*)info)->skip((size_t) bytes);
+}
+
+static void rewind_proc(void* info) {
+    SkASSERT(info);
+    ((SkStream*)info)->rewind();
+}
+
+static void release_info_proc(void* info) {
+    SkASSERT(info);
+    ((SkStream*)info)->unref();
+}
+
+CGDataProviderRef SkCreateDataProviderFromStream(SkStream* stream) {
+    stream->ref();  // unref will be called when the provider is deleted
+
+    const void* addr = stream->getMemoryBase();
+    if (addr) {
+        // special-case when the stream is just a block of ram
+        return CGDataProviderCreateWithData(stream, addr, stream->getLength(),
+                                            unref_proc);
+    }
+
+    CGDataProviderSequentialCallbacks rec;
+    sk_bzero(&rec, sizeof(rec));
+    rec.version = 0;
+    rec.getBytes = get_bytes_proc;
+    rec.skipForward = skip_forward_proc;
+    rec.rewind = rewind_proc;
+    rec.releaseInfo = release_info_proc;
+    return CGDataProviderCreateSequential(stream, &rec);
+}
+
+///////////////////////////////////////////////////////////////////////////////
+
+#include "SkData.h"
+
+CGDataProviderRef SkCreateDataProviderFromData(SkData* data) {
+    data->ref();
+    return CGDataProviderCreateWithData(data, data->data(), data->size(),
+                                            unref_proc);
+}


### PR DESCRIPTION
ability to build Skia for iOS platform have been added in this PR.
For building could be used:
cargo build --target aarch64-apple-ios
@larsbergstrom , could you, please, make code review and accept changes?

There are stubs in this PR. I need to discuss how to do it better add AEGL support.
I am temporary using [this solution](https://github.com/davidandreoletti/libegl) and use servo-egl interface for android, it works but I'm not sure that it is the best way for PR. @larsbergstrom , could you please redirect me to person who worked with egl for android to discuss it?

@larsbergstrom, I'll commit Azure tomorrow - it depends on Skia and will ask you again accept new PR.