### PR TITLE
Update glx dependency to 0.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "servo-skia"
-version = "0.30000006.2"
+version = "0.30000007.0"
 authors = ["The Skia Project Developers and The Servo Project Developers"]
 description = "2D graphic library for drawing Text, Geometries, and Images"
 license = "BSD-3-Clause"
@@ -42,7 +42,7 @@ servo-freetype-sys = "4.0.0"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 x11 = { version = "2.0.0", features = ["xlib"] }
-glx = "0.1.0"
+glx = "0.2"
 
 [target.'cfg(target_os = "android")'.dependencies]
 servo-egl = "0.2"


### PR DESCRIPTION
See https://github.com/servo/rust-glx/pull/17 and servo/gleam#130. We also need this to avoid duplicated versions tidy check failures in order to land the new gleam version in Servo.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/skia/145)
<!-- Reviewable:end -->
