### PR TITLE
Revert the migration to upstream glutin for now.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "servo-skia"
-version = "0.30000011.1"
+version = "0.30000011.2"
 authors = ["The Skia Project Developers and The Servo Project Developers"]
 description = "2D graphic library for drawing Text, Geometries, and Images"
 license = "BSD-3-Clause"
@@ -34,7 +34,7 @@ libc = "0.2"
 expat-sys = "2.1.5"
 
 [target.'cfg(target_os = "windows")'.dependencies]
-glutin = "0.12.1"
+servo-glutin = "0.14"
 
 [target.'cfg(any(target_os = "android", target_os = "linux"))'.dependencies]
 servo-fontconfig-sys = "4.0.0"

--- a/src/gl_context_wgl.rs
+++ b/src/gl_context_wgl.rs
@@ -11,7 +11,6 @@ use gl_rasterization_context;
 use skia;
 
 use euclid::Size2D;
-use gl_context_wgl::glutin::GlContext;
 use gleam::gl;
 use std::ptr;
 use std::rc::Rc;
@@ -53,7 +52,7 @@ impl GLPlatformContext {
             // 32x32 is just the size of the dummy underlying context; the real
             // size is used below when we create the FBO
             let cx = glutin::HeadlessRendererBuilder::new(32, 32).build().unwrap();
-            cx.make_current().expect("make_current failed");
+            cx.make_current();
 
             let gl_interface = skia::SkiaGrGLCreateNativeInterface();
             if gl_interface == ptr::null_mut() {
@@ -98,7 +97,7 @@ impl GLPlatformContext {
 
     pub fn make_current(&self) {
         unsafe {
-            self.context.make_current().expect("make_current failed");
+            self.context.make_current();
         }
     }
 }


### PR DESCRIPTION
Servo is not fully ready to use upstream glutin. And the new dependency on glutin upstream in skia is blocking further skia updates.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/skia/151)
<!-- Reviewable:end -->
