### PR TITLE
build: Don't auto opt-in to ccache.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,12 +7,11 @@ function(set_prefix var prefix)
   set(${var} "${tmp}" PARENT_SCOPE)
 endfunction()
 
-# Use ccache if available
-find_program(CCACHE_FOUND ccache)
-if(CCACHE_FOUND)
-  set_property(GLOBAL PROPERTY RULE_LAUNCH_COMPILE ccache)
-  set_property(GLOBAL PROPERTY RULE_LAUNCH_LINK ccache)
-endif(CCACHE_FOUND)
+# Use ccache if we're told to.
+if(DEFINED ENV{CCACHE})
+  set_property(GLOBAL PROPERTY RULE_LAUNCH_COMPILE $ENV{CCACHE})
+  set_property(GLOBAL PROPERTY RULE_LAUNCH_LINK $ENV{CCACHE})
+endif()
 
 if("$ENV{CFG_ENABLE_DEBUG_SKIA}" STREQUAL "1")
   add_definitions(

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "servo-skia"
-version = "0.30000021.1"
+version = "0.30000021.2"
 authors = ["The Skia Project Developers and The Servo Project Developers"]
 description = "2D graphic library for drawing Text, Geometries, and Images"
 license = "BSD-3-Clause"


### PR DESCRIPTION
Some distros like fedora auto-opt-in to ccache already if installed by putting
symlinks in $PATH (so `clang` points to `/usr/lib64/ccache/clang`).

This uses the same approach as mozjs and others to avoid calling ccache
recursively.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/skia/176)
<!-- Reviewable:end -->
