### PR TITLE
Fix `CCACHE=sccache` with recent sccache versions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,6 @@ endfunction()
 # Use ccache if we're told to.
 if(DEFINED ENV{CCACHE})
   set_property(GLOBAL PROPERTY RULE_LAUNCH_COMPILE $ENV{CCACHE})
-  set_property(GLOBAL PROPERTY RULE_LAUNCH_LINK $ENV{CCACHE})
 endif()
 
 if("$ENV{CFG_ENABLE_DEBUG_SKIA}" STREQUAL "1")

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "servo-skia"
-version = "0.30000023.0"
+version = "0.30000023.1"
 authors = ["The Skia Project Developers and The Servo Project Developers"]
 description = "2D graphic library for drawing Text, Geometries, and Images"
 license = "BSD-3-Clause"


### PR DESCRIPTION
Chosen part of the output with sccache 0.2.12:

```
error: failed to execute compile
caused by: Compiler not supported: "/usr/bin/ar: invalid option -- \'E\'\nUsage: /usr/bin/ar [emulation options] [-]{dmpqrstx}[abcDfilMNoPsSTuvV] [--plugin <name>] [member-name] [count] archive-file file...\n       /usr/bin/ar -M [<mri-script]\n commands:\n  d            - delete file(s) from the archive\n  m[ab]        - move file(s) in the archive\n  p            - print file(s) found in the archive\n  q[f]         - quick append file(s) to the archive\n  r[ab][f][u]  - replace existing or insert new file(s) into the archive\n  s            - act as ranlib\n  t            - display contents of archive\n  x[o]         - extract file(s) from the archive\n command specific modifiers:\n  [a]          - put file(s) after [member-name]\n  [b]          - put file(s) before [member-name] (same as [i])\n  [D]          - use zero for timestamps and uids/gids (default)\n  [U]          - use actual timestamps and uids/gids\n  [N]          - use instance [count] of name\n  [f]          - truncate inserted file names\n  [P]          - use full path names when matching\n  [o]          - preserve original dates\n  [u]          - only replace files that are newer than current archive contents\n generic modifiers:\n  [c]          - do not warn if the library had to be created\n  [s]          - create an archive index (cf. ranlib)\n  [S]          - do not build a symbol table\n  [T]          - make a thin archive\n  [v]          - be verbose\n  [V]          - display the version number\n  @<file>      - read options from <file>\n  --target=BFDNAME - specify the target object format as BFDNAME\n optional:\n  --plugin <p> - load the specified plugin\n emulation options: \n  No emulation specific options\n/usr/bin/ar: supported targets: elf64-x86-64 elf32-i386 elf32-iamcu elf32-x86-64 a.out-i386-linux pei-i386 pei-x86-64 elf64-l1om elf64-k1om elf64-little elf64-big elf32-little elf32-big pe-x86-64 pe-bigobj-x86-64 pe-i386 plugin srec symbolsrec verilog tekhex binary ihex\n"
make[2]: *** [libskia.a] Error 2
make[1]: *** [CMakeFiles/skia.dir/all] Error 2
make: *** [all] Error 2
```

CC https://github.com/servo/servo/pull/24491