### PR TITLE
Remove depedency on servo-freetype-sys

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,8 +37,8 @@ expat-sys = "2.1.5"
 glutin = "0.21.0"
 
 [target.'cfg(any(target_os = "android", target_os = "linux"))'.dependencies]
-servo-fontconfig-sys = "4.0.0"
-servo-freetype-sys = "4.0.0"
+servo-fontconfig-sys = "5.0.0"
+freetype-sys = "0.10.0"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 x11 = { version = "2.0.0", features = ["xlib"] }


### PR DESCRIPTION
This is the last major project depending on the servo-freetype-sys
library. By removing the depedency, the entire ecosystem should now
hopefully rely on only a single system binding for the freetype library.