### PR TITLE
Remove depedency on servo-freetype-sys

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,8 +37,8 @@ expat-sys = "2.1.5"
 glutin = "0.21.0"
 
 [target.'cfg(any(target_os = "android", target_os = "linux"))'.dependencies]
-servo-fontconfig-sys = "4.0.0"
-servo-freetype-sys = "4.0.0"
+servo-fontconfig-sys = { git = "https://github.com/chrisduerr/libfontconfig", branch = "bump_freetype_sys" }
+freetype-sys = "0.11.0"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 x11 = { version = "2.0.0", features = ["xlib"] }


### PR DESCRIPTION
My second attempt at removing the servo-freetype-sys depedency. Now with
the downgraded freetype2 version, this should hopefully build from
source without any troubles.